### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@
 
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/liamsennitt/applocker/security/code-scanning/2](https://github.com/liamsennitt/applocker/security/code-scanning/2)

To fix the issue, add a `permissions` block to the workflow file. Since the workflow does not appear to require write access, the permissions can be limited to `contents: read`. This ensures the workflow adheres to the principle of least privilege while maintaining its functionality.

The `permissions` block should be added at the root level of the workflow file, so it applies to all jobs in the workflow. No additional imports, methods, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
