### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,7 @@
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Publish
+
 permissions:
   contents: read
   packages: write

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,6 +2,9 @@
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 
 name: Publish
+permissions:
+  contents: read
+  packages: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/liamsennitt/applocker/security/code-scanning/1](https://github.com/liamsennitt/applocker/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly define the minimal permissions required for the workflow to function. Since the workflow involves checking out the repository and publishing a package, it needs `contents: read` to read the repository and `packages: write` to publish the package. These permissions will be applied to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
